### PR TITLE
Update log4j to 2.17.1 to address CVE-2021-44832.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <spring.version>5.1.8.RELEASE</spring.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <log4j2.version>2.17.0</log4j2.version>
+        <log4j2.version>2.17.1</log4j2.version>
         <jackson.version>2.13.0</jackson.version>
         <junit.version>4.13.2</junit.version>
         <javax.ws.rs.version>2.0.1</javax.ws.rs.version>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-44832